### PR TITLE
Remove the qpidd-max-unack

### DIFF
--- a/ansible/qpidd.yaml
+++ b/ansible/qpidd.yaml
@@ -2,7 +2,6 @@
 - hosts: all
   remote_user: root
   roles:
-    - qpidd-session-max-unacked
     - qpidd-max-open-files
     - qpidd-fs-aio-max-nr
     - common


### PR DESCRIPTION
Currently qpidd-max-unack breaks satellite install, temporarily remove the role to mitigate the issue