### PR TITLE
Complete Migration to Centralized Tunings File

### DIFF
--- a/ansible/postgresql.yaml
+++ b/ansible/postgresql.yaml
@@ -1,9 +1,11 @@
 ---
 - hosts: all
+  vars_files:
+    - ../conf/tunings.yaml
   remote_user: root
   roles:
     - pretune
     - pgsql-max-connections
     - pgsql-shared-buffers
     - pgsql-work-mem
-    - common 
+    - common

--- a/ansible/puppet.yaml
+++ b/ansible/puppet.yaml
@@ -1,5 +1,7 @@
 ---
 - hosts: all
+  vars_files:
+    - ../conf/tunings.yaml
   remote_user: root
   roles:
     - pretune

--- a/ansible/qdrouterd.yaml
+++ b/ansible/qdrouterd.yaml
@@ -1,5 +1,7 @@
 ---
 - hosts: all
+  vars_files:
+    - ../conf/tunings.yaml
   remote_user: root
   roles:
     - pretune

--- a/ansible/qpidd.yaml
+++ b/ansible/qpidd.yaml
@@ -1,5 +1,7 @@
 ---
 - hosts: all
+  vars_files:
+    - ../conf/tunings.yaml
   remote_user: root
   roles:
     - pretune

--- a/ansible/roles/pgsql-max-connections/tasks/main.yaml
+++ b/ansible/roles/pgsql-max-connections/tasks/main.yaml
@@ -4,7 +4,7 @@
   - name: "Setup postgres max_connections"
     lineinfile:
       dest: /var/lib/pgsql/data/postgresql.conf
-      line: max_connections = 400
+      line: "max_connections = {{ PgsqlMaxConnections }}"
       regexp: "^max_connections"
       state: present
     #when: "ansible_distribution == 'RedHat' and {{ ansible_distribution_version | version_compare('7.0', '>=') }} == 'true'"

--- a/ansible/roles/pgsql-shared-buffers/tasks/main.yaml
+++ b/ansible/roles/pgsql-shared-buffers/tasks/main.yaml
@@ -3,7 +3,7 @@
   - name: "Set postgresql shared_buffers"
     lineinfile:
       dest: /var/lib/pgsql/data/postgresql.conf
-      line: shared_buffers = 512MB
+      line: "shared_buffers = {{ PgsqlSharedBuffers }}"
       regexp: "^shared_buffers"
       state: present
     #when: "ansible_distribution == 'Red Hat Enterprise Linux' and ansible_distribution_version == '7'"

--- a/ansible/roles/pgsql-work-mem/tasks/main.yaml
+++ b/ansible/roles/pgsql-work-mem/tasks/main.yaml
@@ -4,7 +4,7 @@
   - name: "Set postgresql work_mem"
     lineinfile:
       dest: /var/lib/pgsql/data/postgresql.conf
-      line: work_mem = 4MB
+      line: "work_mem = {{ PgsqlWorkMem }}"
       regexp: "^work_mem"
       state: present
     #when: "ansible_distribution == 'Red Hat Enterprise Linux' and ansible_distribution_version == '7'"

--- a/ansible/roles/qpidd-session-max-unacked/tasks/main.yaml
+++ b/ansible/roles/qpidd-session-max-unacked/tasks/main.yaml
@@ -3,7 +3,7 @@
    - name: "Tune qpid session-max-unacked to reduce qpid memory consumption"
      lineinfile:
        dest: /etc/qpid/qpidd.conf
-       line: session-max-unacked=100
+       line: "session-max-unacked={{ QpiddSessionMaxUnacked }}"
        regexp: "^session-max-unacked"
        state: present
 ...

--- a/ansible/roles/smart_proxy_dynflow_core-change-sqlite-storage/tasks/main.yaml
+++ b/ansible/roles/smart_proxy_dynflow_core-change-sqlite-storage/tasks/main.yaml
@@ -4,5 +4,5 @@
     lineinfile:
       dest: /etc/smart_proxy_dynflow_core/settings.yml
       regexp: ":database:"
-      line: ':database: ""'
+      line: ':database: {{ DynflowDatabaseSource }}'
 ...

--- a/ansible/smart_proxy_dynflow_core.yaml
+++ b/ansible/smart_proxy_dynflow_core.yaml
@@ -1,5 +1,7 @@
 ---
 - hosts: capsules
+  vars_files:
+    - ../conf/tunings.yaml
   remote_user: root
   roles:
     - pretune


### PR DESCRIPTION
The PR makes the following changes:
- Integrate centralized tuning file with all the ansible roles
- Adds support for reading tuning.yaml in playbooks