### PR TITLE
Fix minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Ideally, you need two hosts to run this project:
    ```console
      # git clone https://github.com/redhat-performance/satellite-tune.git
    ```
-   NOTE: Optionally you may utilize the script [control_node_setup.sh] (adhoc-scripts/control_node_setup.sh) to perform step 2 below.  The instructions to use this script are documented in the script itself.
+   NOTE: Optionally you may utilize the script [control_node_setup.sh](adhoc-scripts/control_node_setup.sh) to perform step 2 below.  The instructions to use this script are documented in the script itself.
 2. Install `ansible` package on the Control node. For RHEL boxes, [access to EPEL] (https://access.redhat.com/solutions/3358) is required.
 
    ```console


### PR DESCRIPTION
There was an extra space in the control_node_setup.sh link in README.md :)