### PR TITLE
Allow detecting if the disk is a SSD or HDD

### DIFF
--- a/ansible/roles/detect-ssd/tasks/main.yaml
+++ b/ansible/roles/detect-ssd/tasks/main.yaml
@@ -1,0 +1,14 @@
+---
+  - debug:
+      msg: "Checking if the disk {{ satellite_physical_disk }} is SSD"
+  - name: Retrieve the contents of the disk
+    shell:
+      cat "/sys/block/{{ satellite_physical_disk }}/queue/rotational
+    register: is_ssd
+  - set_fact:
+      ssd: true
+    when: "{{ is_ssd.stdout | int }}" == 0
+  - set_fact:
+      ssd: false
+    when: "{{ is_ssd.stdout | int }}" == 1
+...

--- a/conf/sattune.yaml
+++ b/conf/sattune.yaml
@@ -1,0 +1,3 @@
+---
+satellite_physical_disk: /dev/sda 
+...


### PR DESCRIPTION
The PR adds the functionality for detecting if the given disk is a HDD or an SSD.
This information can be obtained from the sysfs which sets the rotational parameter to 1 for HDDs and 0 for SSDs.
The role has a backdrop of not being able to determine the correct behavior in case of RAID volumes.
Signed-off-by: Saurabh Badhwar <sbadhwar@redhat.com>